### PR TITLE
[update] update package for peer-dependencies issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   "author": "alisajames048@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.72.0"
+    "react-native": ">=0.41.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   "author": "alisajames048@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": "^0.72.0"
   }
 }


### PR DESCRIPTION
Hello

In my project, we just upgraded to React Native 0.72.4 and this peer-dependency was preventing us to make a safe npm install and we had to use the `--legacy-peer-dependency` flag that is unsafe.

With this simple change, latest RN versions can use this safely